### PR TITLE
fix(auto): make Android Auto version available again (hopefully)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,12 @@ The process for sideloading apps is pretty simple and a more comprehensive guide
 3. Find the APK on your device using a file manager, and choose to open/install the APK.
 
 **A note on sideloading and Android Auto** <br>
-Android Auto only trusts/shows apps installed via the Play Store, meaning normal sideloading will result in GTRadio not being available in Android Auto. 
-There is a workaround using adb to install the APK that marks the app as installed by the Play Store. 
-More info on that process can be found [here](https://medium.com/@pixplicity/setting-the-install-vendor-of-an-app-7d7deacb01ee).
+Android Auto only trusts/shows apps installed via the Play Store, meaning normal sideloading will result in GTRadio not being available in Android Auto.
+The proper way to handle this is to enable developer mode for Android Auto, then under the Developer settings for Android Auto, check the "Uknown sources" box.
+More details on enabling developer mode for Android Auto can be found [here](https://developer.android.com/training/cars/testing#developer-mode).
+
+> There was also an old workaround using adb to install the APK that marks the app as installed by the Play Store, but this method seems to no longer be reliable.
+> More info on that process can be found [here](https://medium.com/@pixplicity/setting-the-install-vendor-of-an-app-7d7deacb01ee).
 
 
 ## Audio File Setup

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "com.sc.gtradio"
         minSdkVersion 28
         targetSdkVersion 34
-        versionCode 34010100  //Scheme (all two-digit numbers): <api_version><app_major_version><app_minor_version><app_patch_version>
-        versionName "1.1.0"
+        versionCode 34010101  //Scheme (all two-digit numbers): <api_version><app_major_version><app_minor_version><app_patch_version>
+        versionName "1.1.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.GTRadio">
+
         <activity
             android:name=".SettingsActivity"
             android:label="@string/title_activity_settings"

--- a/automotive/build.gradle
+++ b/automotive/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.12.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'androidx.media:media:1.1.0'
+    implementation 'androidx.media3:media3-exoplayer:1.2.1'
     implementation project(path: ':common')
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'

--- a/automotive/build.gradle
+++ b/automotive/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId 'com.sc.gtradio.automotive'
         minSdkVersion 28
         targetSdkVersion 34
-        versionCode 1
-        versionName "1.0"
+        versionCode 34010101  //Scheme (all two-digit numbers): <api_version><app_major_version><app_minor_version><app_patch_version>
+        versionName "1.1.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-feature
+        android:name="android.hardware.type.automotive" />
+    <uses-feature
+        android:name="android.hardware.wifi"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.screen.portrait"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.screen.landscape"
+        android:required="false" />
+
     <application
         android:allowBackup="true"
         android:appCategory="audio"
@@ -23,6 +34,7 @@
         -->
         <service
             android:name="com.sc.gtradio.media.GTRadioMusicService"
+            android:enabled="true"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.media.browse.MediaBrowserService" />
@@ -30,9 +42,4 @@
             </intent-filter>
         </service>
     </application>
-
-    <uses-feature
-        android:name="android.hardware.type.automotive"
-        android:required="true" />
-
 </manifest>


### PR DESCRIPTION
## What is the change?
Updated some manifest requirements and did testing to ensure Android Auto would work. Also updated docs to explain proper method for sideloading.

This will coincide with resubmitting the app to the Play Store now that the API target and auto items have been seemingly addressed.

## In-depth code change information
- Update manifest info (6461800f6739ac3071267ea461ea682443bbd527, 65ff37a1d0ed6a7c826a774249d03e22e28e9ad8)
- Update docs on Android Auto sideloading (2457b51f442e7b5a1bddadde06a54b1b0e90e18c)

## Code areas to focus on
Nothing crazy here

## Related Issue(s)
None