### PR TITLE
fix(news): properly randomize news tracks for Gen3 stations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "com.sc.gtradio"
         minSdkVersion 28
         targetSdkVersion 34
-        versionCode 34010101  //Scheme (all two-digit numbers): <api_version><app_major_version><app_minor_version><app_patch_version>
-        versionName "1.1.1"
+        versionCode 34010102  //Scheme (all two-digit numbers): <api_version><app_major_version><app_minor_version><app_patch_version>
+        versionName "1.1.2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/automotive/build.gradle
+++ b/automotive/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId 'com.sc.gtradio.automotive'
         minSdkVersion 28
         targetSdkVersion 34
-        versionCode 34010101  //Scheme (all two-digit numbers): <api_version><app_major_version><app_minor_version><app_patch_version>
-        versionName "1.1.1"
+        versionCode 34010102  //Scheme (all two-digit numbers): <api_version><app_major_version><app_minor_version><app_patch_version>
+        versionName "1.1.2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/common/src/main/java/com/sc/gtradio/media/stations/Gen3RadioStation.kt
+++ b/common/src/main/java/com/sc/gtradio/media/stations/Gen3RadioStation.kt
@@ -231,6 +231,7 @@ import kotlin.collections.ArrayList
 
     private fun randomizeAll() {
         randomizeAnnouncerFiles()
+        randomizeNewsFiles()
         randomizeAdvertFiles()
         randomizeMainDJFiles()
         randomizeSongs()
@@ -247,6 +248,11 @@ import kotlin.collections.ArrayList
     private fun randomizeAnnouncerFiles() {
         announcerFiles.shuffle()
         announcerIterator = announcerFiles.iterator()
+    }
+
+    private fun randomizeNewsFiles() {
+        newsFiles.shuffle()
+        newsIterator = newsFiles.iterator()
     }
 
     private fun randomizeAdvertFiles() {
@@ -338,7 +344,7 @@ import kotlin.collections.ArrayList
 
     private fun getNextNewsFile(): Uri {
         if (!newsIterator!!.hasNext()) {
-            newsIterator = newsFiles.iterator()
+            randomizeNewsFiles()
         }
         return newsIterator!!.next()
     }
@@ -415,7 +421,7 @@ import kotlin.collections.ArrayList
 
     private fun getNextTalkShow(): Song {
         if (!talkShowIterator!!.hasNext()) {
-            talkShowIterator = talkShows.iterator()
+            randomizeTalkShows()
         }
         return talkShowIterator!!.next()
     }


### PR DESCRIPTION
## What is the change?
Simple fix here. The only collection of files we weren't randomizing before using was the news tracks.

This was discovered over in #16

## In-depth code change information
- Updated initialization of station to include randomizing news tracks. Also caught an issue where talk shows would repeat the same order if you made it through all of them (cd7369ef0b354d39756b54475258f2e6fb6d4dcf)
- Updated to version 1.1.2 (c7aa725cb1ee604ef5c67ac4fe35a64ab774b209)

## Code areas to focus on
Nothing complex here

## Related Issue(s)
Resolves #16
